### PR TITLE
generalize: generalize for use with multiple I2C interfaces

### DIFF
--- a/PCF85063A.cpp
+++ b/PCF85063A.cpp
@@ -2,92 +2,103 @@
 
 
 // INIT
-PCF85063A::PCF85063A(void)
+PCF85063A::PCF85063A(TwoWire *_Wire_Interface = &Wire)
 {
-	Wire.begin();
+    Wire_Interface = _Wire_Interface;
 }
 
 // PUBLIC
-void PCF85063A::setTime(uint8_t hour, uint8_t minute, uint8_t second) 
+bool
+PCF85063A::exist (void)
 {
-	Wire.beginTransmission(I2C_ADDR);
-	Wire.write(RTC_SECOND_ADDR);
-	Wire.write(decToBcd( second) );
-	Wire.write(decToBcd( minute) );
-	Wire.write(decToBcd( hour) );
-	Wire.endTransmission();
+bool RetVal;
+
+Wire_Interface->beginTransmission(PCF85063A_ADDR);
+RetVal = (Wire_Interface->endTransmission() == 0);
+
+return RetVal;
+}
+
+void PCF85063A::setTime(uint8_t hour, uint8_t minute, uint8_t second)
+{
+	Wire_Interface->beginTransmission(PCF85063A_ADDR);
+	Wire_Interface->write(PCF85063A_SECOND_ADDR);
+	Wire_Interface->write(decToBcd( second) );
+	Wire_Interface->write(decToBcd( minute) );
+	Wire_Interface->write(decToBcd( hour) );
+	Wire_Interface->endTransmission();
 }
 
 void PCF85063A::setDate(uint8_t weekday, uint8_t day, uint8_t month, uint8_t yr)
 {
 	year = yr - 1970; 	// convert to RTC year format 0-99
 
-	Wire.beginTransmission(I2C_ADDR);
-	Wire.write(RTC_DAY_ADDR);
-	Wire.write( decToBcd(day) );
-	Wire.write( decToBcd(weekday) );
-	Wire.write( decToBcd(month) );
-	Wire.write( decToBcd(year) );
-	Wire.endTransmission();
+	Wire_Interface->beginTransmission(PCF85063A_ADDR);
+	Wire_Interface->write(PCF85063A_DAY_ADDR);
+	Wire_Interface->write( decToBcd(day) );
+	Wire_Interface->write( decToBcd(weekday) );
+	Wire_Interface->write( decToBcd(month) );
+	Wire_Interface->write( decToBcd(year) );
+	Wire_Interface->endTransmission();
 }
 
-void PCF85063A::readTime() 
+void PCF85063A::readTime()
 {
-	Wire.beginTransmission(I2C_ADDR);
-	Wire.write(RTC_SECOND_ADDR);					// datasheet 8.4.
-	Wire.endTransmission();
+	Wire_Interface->beginTransmission(PCF85063A_ADDR);
+	Wire_Interface->write(PCF85063A_SECOND_ADDR);					// datasheet 8.4.
+	Wire_Interface->endTransmission();
 
-	Wire.requestFrom(I2C_ADDR, 7);
+	Wire_Interface->requestFrom(PCF85063A_ADDR, 7);
 
-	while( Wire.available() )
+	while( Wire_Interface->available() )
 	{
-		second = bcdToDec( Wire.read() & 0x7F ); 	// ignore bit 7
-		minute = bcdToDec( Wire.read() & 0x7F );
-		hour = bcdToDec( Wire.read() & 0x3F );		// ignore bits 7 & 6
-		day = bcdToDec( Wire.read() & 0x3F );
-		weekday = bcdToDec( Wire.read() & 0x07);	// ignore bits 7,6,5,4 & 3
-		month = bcdToDec( Wire.read() & 0x1F);		// ignore bits 7,6 & 5
-		year = bcdToDec( Wire.read()) + 1970;
+		second = bcdToDec( Wire_Interface->read() & 0x7F ); 	// ignore bit 7
+		minute = bcdToDec( Wire_Interface->read() & 0x7F );
+		hour = bcdToDec( Wire_Interface->read() & 0x3F );		// ignore bits 7 & 6
+		day = bcdToDec( Wire_Interface->read() & 0x3F );
+		weekday = bcdToDec( Wire_Interface->read() & 0x07);	// ignore bits 7,6,5,4 & 3
+		month = bcdToDec( Wire_Interface->read() & 0x1F);		// ignore bits 7,6 & 5
+		year = bcdToDec( Wire_Interface->read()) + 1970;
 	}
 }
 
-uint8_t PCF85063A::getSecond() 
+uint8_t PCF85063A::getSecond()
 {
 	readTime();
 	return second;
 }
 
-uint8_t PCF85063A::getMinute() 
+uint8_t PCF85063A::getMinute()
 {
 	readTime();
 	return minute;
 }
 
-uint8_t PCF85063A::getHour() 
+uint8_t PCF85063A::getHour()
 {
 	readTime();
 	return hour;
 }
 
-uint8_t PCF85063A::getDay() 
+uint8_t PCF85063A::getDay()
 {
 	readTime();
 	return day;
 }
 
-uint8_t PCF85063A::getWeekday() 
+uint8_t PCF85063A::getWeekday()
 {
 	readTime();
 	return weekday;
 }
 
-uint8_t PCF85063A::getMonth() 
+uint8_t PCF85063A::getMonth()
 {
 	readTime();
 	return month;
 }
 
-uint16_t PCF85063A::getYear() 
+uint16_t PCF85063A::getYear()
 {
 	readTime();
 	return year;
@@ -96,13 +107,13 @@ uint16_t PCF85063A::getYear()
 void PCF85063A::enableAlarm() // datasheet 8.5.6.
 {
 	// check Table 2. Control_2
-	control_2 = RTC_CTRL_2_DEFAULT | RTC_ALARM_AIE; 	// enable interrupt
-	control_2 &= ~RTC_ALARM_AF;							// clear alarm flag
+	control_2 = PCF85063A_CTRL_2_DEFAULT | PCF85063A_ALARM_AIE; 	// enable interrupt
+	control_2 &= ~PCF85063A_ALARM_AF;							// clear alarm flag
 
-	Wire.beginTransmission(I2C_ADDR);
-	Wire.write(RTC_CTRL_2);
-	Wire.write(control_2);
-	Wire.endTransmission();
+	Wire_Interface->beginTransmission(PCF85063A_ADDR);
+	Wire_Interface->write(PCF85063A_CTRL_2);
+	Wire_Interface->write(control_2);
+	Wire_Interface->endTransmission();
 }
 
 void PCF85063A::setAlarm(uint8_t alarm_second, uint8_t alarm_minute, uint8_t alarm_hour, uint8_t alarm_day, uint8_t alarm_weekday)
@@ -110,102 +121,102 @@ void PCF85063A::setAlarm(uint8_t alarm_second, uint8_t alarm_minute, uint8_t ala
 	if (alarm_second <99) {										// second
         alarm_second = constrain(alarm_second, 0, 59);
         alarm_second = decToBcd(alarm_second);
-        alarm_second &= ~RTC_ALARM;
+        alarm_second &= ~PCF85063A_ALARM;
     } else {
-        alarm_second = 0x0; alarm_second |= RTC_ALARM;
+        alarm_second = 0x0; alarm_second |= PCF85063A_ALARM;
     }
 
 	if (alarm_minute <99) {										// minute
         alarm_minute = constrain(alarm_minute, 0, 59);
         alarm_minute = decToBcd(alarm_minute);
-        alarm_minute &= ~RTC_ALARM;
+        alarm_minute &= ~PCF85063A_ALARM;
     } else {
-        alarm_minute = 0x0; alarm_minute |= RTC_ALARM;
+        alarm_minute = 0x0; alarm_minute |= PCF85063A_ALARM;
     }
 
     if (alarm_hour <99) {										// hour
         alarm_hour = constrain(alarm_hour, 0, 23);
         alarm_hour = decToBcd(alarm_hour);
-        alarm_hour &= ~RTC_ALARM;
+        alarm_hour &= ~PCF85063A_ALARM;
     } else {
-        alarm_hour = 0x0; alarm_hour |= RTC_ALARM;
+        alarm_hour = 0x0; alarm_hour |= PCF85063A_ALARM;
     }
 
     if (alarm_day <99) {										// day
         alarm_day = constrain(alarm_day, 1, 31);
-        alarm_day = decToBcd(alarm_day); 
-        alarm_day &= ~RTC_ALARM;
+        alarm_day = decToBcd(alarm_day);
+        alarm_day &= ~PCF85063A_ALARM;
     } else {
-        alarm_day = 0x0; alarm_day |= RTC_ALARM;
+        alarm_day = 0x0; alarm_day |= PCF85063A_ALARM;
     }
 
     if (alarm_weekday <99) {									// weekday
         alarm_weekday = constrain(alarm_weekday, 0, 6);
         alarm_weekday = decToBcd(alarm_weekday);
-        alarm_weekday &= ~RTC_ALARM;
+        alarm_weekday &= ~PCF85063A_ALARM;
     } else {
-        alarm_weekday = 0x0; alarm_weekday |= RTC_ALARM;
+        alarm_weekday = 0x0; alarm_weekday |= PCF85063A_ALARM;
     }
 
     enableAlarm();
 
-    Wire.beginTransmission(I2C_ADDR);
-    Wire.write(RTC_SECOND_ALARM);
-    Wire.write(alarm_second);
-    Wire.write(alarm_minute);
-    Wire.write(alarm_hour);
-    Wire.write(alarm_day);
-    Wire.write(alarm_weekday);
-    Wire.endTransmission();
+    Wire_Interface->beginTransmission(PCF85063A_ADDR);
+    Wire_Interface->write(PCF85063A_SECOND_ALARM);
+    Wire_Interface->write(alarm_second);
+    Wire_Interface->write(alarm_minute);
+    Wire_Interface->write(alarm_hour);
+    Wire_Interface->write(alarm_day);
+    Wire_Interface->write(alarm_weekday);
+    Wire_Interface->endTransmission();
 }
 
-void PCF85063A::readAlarm() 
+void PCF85063A::readAlarm()
 {
-	Wire.beginTransmission(I2C_ADDR);
-	Wire.write(RTC_SECOND_ALARM);					// datasheet 8.4.
-	Wire.endTransmission();
+	Wire_Interface->beginTransmission(PCF85063A_ADDR);
+	Wire_Interface->write(PCF85063A_SECOND_ALARM);					// datasheet 8.4.
+	Wire_Interface->endTransmission();
 
-	Wire.requestFrom(I2C_ADDR, 5);
+	Wire_Interface->requestFrom(PCF85063A_ADDR, 5);
 
-	while( Wire.available() )
+	while( Wire_Interface->available() )
 	{
-		alarm_second = Wire.read(); 				// read RTC_SECOND_ALARM register
-		if( RTC_ALARM &  alarm_second)				// check is AEN = 1 (second alarm disabled)
+		alarm_second = Wire_Interface->read(); 				// read PCF85063A_SECOND_ALARM register
+		if( PCF85063A_ALARM &  alarm_second)				// check is AEN = 1 (second alarm disabled)
 		{
 			alarm_second = 99;						// using 99 as code for no alarm
 		} else {									// else if AEN = 0 (second alarm enabled)
-			alarm_second = bcdToDec( alarm_second & ~RTC_ALARM);	// remove AEN flag and convert to dec number
+			alarm_second = bcdToDec( alarm_second & ~PCF85063A_ALARM);	// remove AEN flag and convert to dec number
 		}
 
-		alarm_minute = Wire.read(); 				// minute
-		if( RTC_ALARM &  alarm_minute)				
+		alarm_minute = Wire_Interface->read(); 				// minute
+		if( PCF85063A_ALARM &  alarm_minute)
 		{
-			alarm_minute = 99;						
-		} else {									
-			alarm_minute = bcdToDec( alarm_minute & ~RTC_ALARM);	
+			alarm_minute = 99;
+		} else {
+			alarm_minute = bcdToDec( alarm_minute & ~PCF85063A_ALARM);
 		}
 
-		alarm_hour = Wire.read(); 				// hour
-		if( RTC_ALARM &  alarm_hour)				
+		alarm_hour = Wire_Interface->read(); 				// hour
+		if( PCF85063A_ALARM &  alarm_hour)
 		{
-			alarm_hour = 99;						
-		} else {									
+			alarm_hour = 99;
+		} else {
 			alarm_hour = bcdToDec( alarm_hour & 0x3F);	// remove bits 7 & 6
 		}
 
-		alarm_day = Wire.read(); 				// day
-		if( RTC_ALARM &  alarm_day)				
+		alarm_day = Wire_Interface->read(); 				// day
+		if( PCF85063A_ALARM &  alarm_day)
 		{
-			alarm_day = 99;						
-		} else {									
+			alarm_day = 99;
+		} else {
 			alarm_day = bcdToDec( alarm_day & 0x3F);	// remove bits 7 & 6
 		}
 
-		alarm_weekday = Wire.read(); 				// weekday
-		if( RTC_ALARM &  alarm_weekday)				
+		alarm_weekday = Wire_Interface->read(); 				// weekday
+		if( PCF85063A_ALARM &  alarm_weekday)
 		{
-			alarm_weekday = 99;						
-		} else {									
+			alarm_weekday = 99;
+		} else {
 			alarm_weekday = bcdToDec( alarm_weekday & 0x07);	// remove bits 7,6,5,4 & 3
 		}
 	}
@@ -246,53 +257,53 @@ void PCF85063A::timerSet(CountdownSrcClock source_clock, uint8_t value, bool int
 	uint8_t timer_reg[2] = {0};
 
 	// disable the countdown timer
-	Wire.beginTransmission(I2C_ADDR);
-	Wire.write(RTC_TIMER_MODE);
-	Wire.write(0x18);	// default
-	Wire.endTransmission();
+	Wire_Interface->beginTransmission(PCF85063A_ADDR);
+	Wire_Interface->write(PCF85063A_TIMER_MODE);
+	Wire_Interface->write(0x18);	// default
+	Wire_Interface->endTransmission();
 
 	// clear Control_2
-	Wire.beginTransmission(I2C_ADDR);
-	Wire.write(RTC_CTRL_2);
-	Wire.write(0x00);	// default
-	Wire.endTransmission();
+	Wire_Interface->beginTransmission(PCF85063A_ADDR);
+	Wire_Interface->write(PCF85063A_CTRL_2);
+	Wire_Interface->write(0x00);	// default
+	Wire_Interface->endTransmission();
 
 	// reconfigure timer
-	timer_reg[1] |= RTC_TIMER_TE;						// enable timer
-	if (int_enable) timer_reg[1] |= RTC_TIMER_TIE;		// enable interrupr
-	if (int_pulse) timer_reg[1] |= RTC_TIMER_TI_TP;		// interrupt mode
+	timer_reg[1] |= PCF85063A_TIMER_TE;						// enable timer
+	if (int_enable) timer_reg[1] |= PCF85063A_TIMER_TIE;		// enable interrupr
+	if (int_pulse) timer_reg[1] |= PCF85063A_TIMER_TI_TP;		// interrupt mode
 	timer_reg[1] |= source_clock << 3;					// clock source
 	//timer_reg[1] = 0b00011111;
 
 	timer_reg[0] = value;
-	
+
 	// write timer value
-	Wire.beginTransmission(I2C_ADDR);
-	Wire.write(RTC_TIMER_VAL);
-	Wire.write(timer_reg[0]);
-	Wire.write(timer_reg[1]);
-	Wire.endTransmission();
+	Wire_Interface->beginTransmission(PCF85063A_ADDR);
+	Wire_Interface->write(PCF85063A_TIMER_VAL);
+	Wire_Interface->write(timer_reg[0]);
+	Wire_Interface->write(timer_reg[1]);
+	Wire_Interface->endTransmission();
 }
 
 bool PCF85063A::checkTimerFlag()
 {
-	uint8_t _crtl_2 = RTC_TIMER_FLAG;
+	uint8_t _crtl_2 = PCF85063A_TIMER_FLAG;
 
-	Wire.beginTransmission(I2C_ADDR);
-	Wire.write(RTC_CTRL_2);
-	Wire.endTransmission();
-	Wire.requestFrom(I2C_ADDR, 1);
-	_crtl_2 &= Wire.read();
+	Wire_Interface->beginTransmission(PCF85063A_ADDR);
+	Wire_Interface->write(PCF85063A_CTRL_2);
+	Wire_Interface->endTransmission();
+	Wire_Interface->requestFrom(PCF85063A_ADDR, 1);
+	_crtl_2 &= Wire_Interface->read();
 
 	return _crtl_2;
 }
 
 void PCF85063A::reset()	// datasheet 8.2.1.3.
 {
-	Wire.beginTransmission(I2C_ADDR);
-	Wire.write(RTC_CTRL_1);
-	Wire.write(0x58);
-	Wire.endTransmission();
+	Wire_Interface->beginTransmission(PCF85063A_ADDR);
+	Wire_Interface->write(PCF85063A_CTRL_1);
+	Wire_Interface->write(0x58);
+	Wire_Interface->endTransmission();
 }
 
 

--- a/PCF85063A.h
+++ b/PCF85063A.h
@@ -4,49 +4,51 @@
 #include "Arduino.h"
 #include "Wire.h"
 
-#define I2C_ADDR            0x51
+#define PCF85063A_ADDR            0x51
 
 // registar overview - crtl & status reg
-#define RTC_CTRL_1 			0x0
-#define RTC_CTRL_2 			0x01
-#define RTC_OFFSET 			0x02
-#define RTC_RAM_by 			0x03
+#define PCF85063A_CTRL_1 			0x0
+#define PCF85063A_CTRL_2 			0x01
+#define PCF85063A_OFFSET 			0x02
+#define PCF85063A_RAM_by 			0x03
 // registar overview - time & data reg
-#define RTC_SECOND_ADDR		0x04
-#define RTC_MINUTE_ADDR		0x05
-#define RTC_HOUR_ADDR		0x06
-#define RTC_DAY_ADDR		0x07
-#define RTC_WDAY_ADDR		0x08
-#define RTC_MONTH_ADDR		0x09
-#define RTC_YEAR_ADDR		0x0A	// years 0-99; calculate real year = 1970 + RCC reg year
+#define PCF85063A_SECOND_ADDR		0x04
+#define PCF85063A_MINUTE_ADDR		0x05
+#define PCF85063A_HOUR_ADDR		0x06
+#define PCF85063A_DAY_ADDR		0x07
+#define PCF85063A_WDAY_ADDR		0x08
+#define PCF85063A_MONTH_ADDR		0x09
+#define PCF85063A_YEAR_ADDR		0x0A	// years 0-99; calculate real year = 1970 + RCC reg year
 // registar overview - alarm reg
-#define RTC_SECOND_ALARM	0x0B
-#define RTC_MINUTE_ALARM	0x0C
-#define RTC_HOUR_ALARM		0x0D
-#define RTC_DAY_ALARM		0x0E
-#define RTC_WDAY_ALARM		0x0F
+#define PCF85063A_SECOND_ALARM	0x0B
+#define PCF85063A_MINUTE_ALARM	0x0C
+#define PCF85063A_HOUR_ALARM		0x0D
+#define PCF85063A_DAY_ALARM		0x0E
+#define PCF85063A_WDAY_ALARM		0x0F
 // registar overview - timer reg
-#define RTC_TIMER_VAL 		0x10
-#define RTC_TIMER_MODE		0x11
-#define RTC_TIMER_TCF        0x08
-#define RTC_TIMER_TE         0x04
-#define RTC_TIMER_TIE        0x02
-#define RTC_TIMER_TI_TP      0x01
-// format 
-#define RTC_ALARM 			0x80	// set AEN_x registers
-#define RTC_ALARM_AIE		0x80 	// set AIE ; enable/disable interrupt output pin
-#define RTC_ALARM_AF		0x40 	// set AF register ; alarm flag needs to be cleared for alarm
-#define RTC_CTRL_2_DEFAULT	0x00
-#define RTC_TIMER_FLAG		0x08
+#define PCF85063A_TIMER_VAL 		0x10
+#define PCF85063A_TIMER_MODE		0x11
+#define PCF85063A_TIMER_TCF        0x08
+#define PCF85063A_TIMER_TE         0x04
+#define PCF85063A_TIMER_TIE        0x02
+#define PCF85063A_TIMER_TI_TP      0x01
+// format
+#define PCF85063A_ALARM 			0x80	// set AEN_x registers
+#define PCF85063A_ALARM_AIE		0x80 	// set AIE ; enable/disable interrupt output pin
+#define PCF85063A_ALARM_AF		0x40 	// set AF register ; alarm flag needs to be cleared for alarm
+#define PCF85063A_CTRL_2_DEFAULT	0x00
+#define PCF85063A_TIMER_FLAG		0x08
 
 class PCF85063A {
 	public:
-		PCF85063A();
+		PCF85063A(TwoWire *_Wire_Interface);
 
 	    enum CountdownSrcClock {TIMER_CLOCK_4096HZ   = 0,
                  		TIMER_CLOCK_64HZ     = 1,
                  		TIMER_CLOCK_1HZ      = 2,
                  		TIMER_CLOCK_1PER60HZ = 3 };
+
+        bool exist (void);
 
 		void setTime(uint8_t hour, uint8_t minute, uint8_t sec);
 		void setDate(uint8_t weekday, uint8_t day, uint8_t month, uint8_t yr);
@@ -74,6 +76,7 @@ class PCF85063A {
 		uint8_t getAlarmWeekday();
 
 	private:
+        TwoWire *Wire_Interface;
 		uint8_t decToBcd(uint8_t val);
 		uint8_t bcdToDec(uint8_t val);
 		/* time variables */

--- a/examples/alarm_interrupt_sleep/alarm_interrupt_sleep.ino
+++ b/examples/alarm_interrupt_sleep/alarm_interrupt_sleep.ino
@@ -1,20 +1,23 @@
+#include <Wire.h>
 #include "PCF85063A.h"
-#include <avr/sleep.h>  
+#include <avr/sleep.h>
 
-PCF85063A rtc;
-  
-int wakePin = 2;                 // pin used for waking up  
+PCF85063A rtc(&Wire);
 
-void wakeUpNow() {  
-  sleep_disable();         // first thing after waking from sleep: disable sleep...  
-  detachInterrupt(0);      // disables interrupt 0 on pin 2 so the wakeUpNow code will not be executed during normal running time.  
-}  
-  
-void setup() {  
+int wakePin = 2;                 // pin used for waking up
+
+void wakeUpNow() {
+  sleep_disable();         // first thing after waking from sleep: disable sleep...
+  detachInterrupt(0);      // disables interrupt 0 on pin 2 so the wakeUpNow code will not be executed during normal running time.
+}
+
+void setup() {
   Serial.begin(115200);
-  
-  pinMode(wakePin, INPUT_PULLUP);  
-  pinMode(LED_BUILTIN, OUTPUT);     
+
+  Wire.begin();
+
+  pinMode(wakePin, INPUT_PULLUP);
+  pinMode(LED_BUILTIN, OUTPUT);
 
   //  setTime(hour, minute, sec);
   rtc.setTime(6, 54, 00);           // 24H mode, ex. 6:54:00
@@ -25,17 +28,17 @@ void setup() {
   checkAlarm();
 
   Serial.print("Now is:" );
-}   
-  
-void loop() {  
+}
+
+void loop() {
   printCurrentTime();
   Serial.println("Entering sleep mode in 1 second");
   delay(1000);
-  
+
   sleepNow();     // sleep function called here
-  
-  Serial.print("Interrupt triggered on: ");  
-}  
+
+  Serial.print("Interrupt triggered on: ");
+}
 
 void printCurrentTime() {
   switch( rtc.getWeekday() )
@@ -109,12 +112,12 @@ void checkAlarm() {
 }
 
 void sleepNow() {
-    sleep_enable();                         // enables the sleep bit in the mcucr register  
-    attachInterrupt(0,wakeUpNow, LOW);      // use interrupt 0 (pin 2) and run function 
-    set_sleep_mode(SLEEP_MODE_PWR_DOWN);    // sleep mode is set here  
-    digitalWrite(LED_BUILTIN, LOW); 
-    sleep_cpu();                            // activating sleep 
-     
+    sleep_enable();                         // enables the sleep bit in the mcucr register
+    attachInterrupt(0,wakeUpNow, LOW);      // use interrupt 0 (pin 2) and run function
+    set_sleep_mode(SLEEP_MODE_PWR_DOWN);    // sleep mode is set here
+    digitalWrite(LED_BUILTIN, LOW);
+    sleep_cpu();                            // activating sleep
+
     // THE PROGRAM CONTINUES FROM HERE AFTER WAKING UP
-    digitalWrite(LED_BUILTIN, HIGH);  
-} 
+    digitalWrite(LED_BUILTIN, HIGH);
+}

--- a/examples/basic/basic.ino
+++ b/examples/basic/basic.ino
@@ -1,21 +1,23 @@
+#include <Wire.h>
 #include "PCF85063A.h"
 
-PCF85063A rtc;
- 
-  
-void setup() {  
-  Serial.begin(115200);  
+PCF85063A rtc(&Wire);
+
+void setup() {
+  Serial.begin(115200);
+
+  Wire.begin();
 
   //  setTime(hour, minute, sec);
   rtc.setTime(6, 54, 00);           // 24H mode, ex. 6:54:00
   //  setDate(weekday, day, month, yr);
   rtc.setDate(6, 16, 5, 2020);      // 0 for Sunday, ex. Saturday, 16.5.2020.
-}   
-  
-void loop() {  
+}
+
+void loop() {
   printCurrentTime();
   delay(1000);
-}  
+}
 
 void printCurrentTime() {
   switch( rtc.getWeekday() )

--- a/examples/timer/timer.ino
+++ b/examples/timer/timer.ino
@@ -1,11 +1,14 @@
+#include <Wire.h>
 #include "PCF85063A.h"
 
-PCF85063A rtc;
- 
-uint8_t countdown_time = 5;    // timer countdown in seconds  
-  
-void setup() {  
-  Serial.begin(115200); 
+PCF85063A rtc(&Wire);
+
+uint8_t countdown_time = 5;    // timer countdown in seconds
+
+void setup() {
+  Serial.begin(115200);
+
+  Wire1.begin();
 
   //  setTime(hour, minute, sec);
   rtc.setTime(6, 54, 00);           // 24H mode, ex. 6:54:00
@@ -13,18 +16,18 @@ void setup() {
   rtc.setDate(6, 16, 5, 2020);      // 0 for Sunday, ex. Saturday, 16.5.2020.
 
   Serial.print("Now is:" );
-}   
-  
-void loop() {  
+}
+
+void loop() {
   printCurrentTime();
   Serial.print("Setting timer countdown, waking up in "); Serial.print(countdown_time); Serial.println(" seconds.");
   //while(!Serial.available());
-  
+
  /*   source_clock
-  *       PCF85063A::TIMER_CLOCK_4096HZ     -> clk = 4096Hz -> min timer = 244uS -> MAX timer = 62.256mS        
+  *       PCF85063A::TIMER_CLOCK_4096HZ     -> clk = 4096Hz -> min timer = 244uS -> MAX timer = 62.256mS
   *       PCF85063A::TIMER_CLOCK_64HZ       -> clk = 64Hz   -> min timer = 15.625mS -> MAX timer = 3.984s
   *       PCF85063A::TIMER_CLOCK_1HZ        -> clk = 1Hz    -> min timer = 1s -> MAX timer = 255s
-  *       PCF85063A::TIMER_CLOCK_1PER60HZ   -> clk = 1/60Hz -> min timer = 60s -> MAX timer = 4h15min  
+  *       PCF85063A::TIMER_CLOCK_1PER60HZ   -> clk = 1/60Hz -> min timer = 60s -> MAX timer = 4h15min
   *   value
   *       coundowntime in seconds
   *   int_enable
@@ -33,15 +36,15 @@ void loop() {
   *       true = interrupt generate a pulse; false = interrupt follows timer flag
   */
   rtc.timerSet(PCF85063A::TIMER_CLOCK_1HZ, countdown_time, false, false);
-  
+
   Serial.print("Waiting for a countdown");
   while(! rtc.checkTimerFlag() ) {
     Serial.print(".");
     delay(1000);
-  } 
- 
-  Serial.print("\nInterrupt triggered on: ");  
-}  
+  }
+
+  Serial.print("\nInterrupt triggered on: ");
+}
 
 void printCurrentTime() {
   switch( rtc.getWeekday() )


### PR DESCRIPTION
Generalize code to use with different I2C interfaces. Changed I2C address symbol name to avoid conflict.

Signed-off-by: Dean Weiten <dmw@weiten.com>